### PR TITLE
encode error fix

### DIFF
--- a/dss.py
+++ b/dss.py
@@ -30,7 +30,8 @@ def requestQuery(query):
 		headers=header
 	)
 	#print(res.encoding);
-	text=res.text.encode('utf-8')
+	res.encoding='utf-8'
+	text=res.text
 	idx=text.find('<div id="resultStats">')+len('<div id="resultStats">')
 	fidx=text.find('<nobr>',idx)
 	textfound=text[idx:fidx]


### PR DESCRIPTION
This is probably what you want according to http://docs.python-requests.org/en/master/user/quickstart/
With the res.text.encode() function it converted the text in a bytes-like object and the rest of the program did not work since it expects a string object.